### PR TITLE
Update shift out data option to accept a register

### DIFF
--- a/approved/rww_test.atp
+++ b/approved/rww_test.atp
@@ -1,0 +1,241 @@
+// ***************************************************************************
+// GENERATED:
+//   Time:    16-Jun-2017 15:28PM
+//   By:      pderouen
+//   Command: origen g rww_test -t debug_RH4.rb -e j750.rb
+// ***************************************************************************
+// ENVIRONMENT:
+//   Application
+//     Source:    git@github.com:Origen-SDK/origen_jtag.git
+//     Version:   0.15.0
+//     Branch:    update_rd_while_wr(d6173ae2e97) (+local edits)
+//   Origen
+//     Source:    https://github.com/Origen-SDK/origen
+//     Version:   0.7.45
+//   Plugins
+//     atp:                      0.5.0
+//     origen_doc_helpers:       0.4.4
+//     origen_testers:           0.9.0
+// ***************************************************************************
+import tset nvmbist;                                                                            
+svm_only_file = no;                                                                             
+opcode_mode = extended;                                                                         
+compressed = yes;                                                                               
+                                                                                                
+vector ($tset, tclk, tdi, tdo, tms)                                                             
+{                                                                                               
+start_label pattern_st:                                                                         
+//                                                                                              t t t t
+//                                                                                              c d d m
+//                                                                                              l i o s
+//                                                                                              k      
+// TDO should be HLHL_LHLH_HLHL_LHLH
+// [JTAG] Force transition to Run-Test/Idle...
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 0 ;
+repeat 2                                                         > nvmbist                      1 X X 0 ;
+repeat 2                                                         > nvmbist                      0 X X 0 ;
+repeat 2                                                         > nvmbist                      1 X X 0 ;
+// [JTAG] Transition to Shift-DR...
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 0 ;
+repeat 2                                                         > nvmbist                      1 X X 0 ;
+repeat 2                                                         > nvmbist                      0 X X 0 ;
+repeat 2                                                         > nvmbist                      1 X X 0 ;
+// [JTAG] Write DR: 0xFFFF
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+repeat 2                                                         > nvmbist                      0 1 X 1 ;
+repeat 2                                                         > nvmbist                      1 1 H 1 ;
+// [JTAG] /Write DR: 0xFFFF
+repeat 2                                                         > nvmbist                      0 1 X 1 ;
+repeat 2                                                         > nvmbist                      1 1 X 1 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+// TDO should be XXXX_XXXX_HHHH_HHHH
+// [JTAG] Transition to Shift-DR...
+repeat 2                                                         > nvmbist                      0 1 X 1 ;
+repeat 2                                                         > nvmbist                      1 1 X 1 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+// [JTAG] Write DR: 0xFFFF
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+repeat 2                                                         > nvmbist                      0 1 X 1 ;
+repeat 2                                                         > nvmbist                      1 1 X 1 ;
+// [JTAG] /Write DR: 0xFFFF
+repeat 2                                                         > nvmbist                      0 1 X 1 ;
+repeat 2                                                         > nvmbist                      1 1 X 1 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+// TDO should be HLHL_LHLH_HLHL_LHLH
+// [JTAG] Transition to Shift-DR...
+repeat 2                                                         > nvmbist                      0 1 X 1 ;
+repeat 2                                                         > nvmbist                      1 1 X 1 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+// [JTAG] Write DR: 0xFFFF
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+repeat 2                                                         > nvmbist                      0 1 X 1 ;
+repeat 2                                                         > nvmbist                      1 1 H 1 ;
+// [JTAG] /Write DR: 0xFFFF
+repeat 2                                                         > nvmbist                      0 1 X 1 ;
+repeat 2                                                         > nvmbist                      1 1 X 1 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+// TDO should be XXXX_XXXX_HHHH_HHHH
+// [JTAG] Transition to Shift-DR...
+repeat 2                                                         > nvmbist                      0 1 X 1 ;
+repeat 2                                                         > nvmbist                      1 1 X 1 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+// [JTAG] Write DR: 0xFFFF
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+repeat 2                                                         > nvmbist                      0 1 X 1 ;
+repeat 2                                                         > nvmbist                      1 1 X 1 ;
+// [JTAG] /Write DR: 0xFFFF
+repeat 2                                                         > nvmbist                      0 1 X 1 ;
+repeat 2                                                         > nvmbist                      1 1 X 1 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+// ######################################################################
+// ## Pattern complete
+// ######################################################################
+end_module                                                       > nvmbist                      1 1 X 0 ;
+}                                                                                               

--- a/config/commands.rb
+++ b/config/commands.rb
@@ -46,6 +46,9 @@ when "examples", "test"
   ARGV = %w(jtag_workout -t debug_RL4 -e j750.rb -r approved)
   load "#{Origen.top}/lib/origen/commands/generate.rb"
   
+  ARGV = %w(rww_test -t debug_RH4 -e j750.rb -r approved)
+  load "#{Origen.top}/lib/origen/commands/generate.rb"
+
   if Origen.app.stats.changed_files == 0 &&
      Origen.app.stats.new_files == 0 &&
      Origen.app.stats.changed_patterns == 0 &&

--- a/lib/origen_jtag/driver.rb
+++ b/lib/origen_jtag/driver.rb
@@ -547,8 +547,12 @@ module OrigenJTAG
           tdo.read
         else
           if options[:shift_out_data]
-            tdo.write(options[:shift_out_data])
-            tdo.read
+            if options[:shift_out_data].is_a?(Origen::Registers::Reg)
+              tdo = options[:shift_out_data]
+            else
+              tdo.write(options[:shift_out_data])
+              tdo.read
+            end
           else
             tdo.write(0)
           end

--- a/lib/origen_jtag/driver.rb
+++ b/lib/origen_jtag/driver.rb
@@ -523,10 +523,12 @@ module OrigenJTAG
     #   where caller has requested (specific) shift out data to be compared.
     def extract_shift_out_data(reg_or_val, size, options = {})
       if reg_or_val.respond_to?(:data)
-        if options[:read]
+        if options[:read] || options[:shift_out_data]
           tdo = reg_or_val.dup
         else
           tdo = Reg.dummy(size)
+        end
+        if !options[:read]
           if options[:shift_out_data]
             tdo.write(options[:shift_out_data])
             tdo.read

--- a/lib/origen_jtag/driver.rb
+++ b/lib/origen_jtag/driver.rb
@@ -523,15 +523,19 @@ module OrigenJTAG
     #   where caller has requested (specific) shift out data to be compared.
     def extract_shift_out_data(reg_or_val, size, options = {})
       if reg_or_val.respond_to?(:data)
-        if options[:read] || options[:shift_out_data]
+        if options[:read]
           tdo = reg_or_val.dup
         else
-          tdo = Reg.dummy(size)
+          tdo = Reg.dummy(size) unless options[:shift_out_data].is_a?(Origen::Registers::Reg)
         end
-        unless options[:read]
+        unless options[:read]			# if this is a write operation
           if options[:shift_out_data]
-            tdo.write(options[:shift_out_data])
-            tdo.read
+            if options[:shift_out_data].is_a?(Origen::Registers::Reg)
+              tdo = options[:shift_out_data]
+            else
+              tdo.write(options[:shift_out_data])
+              tdo.read
+            end
           else
             tdo.write(0)
           end

--- a/lib/origen_jtag/driver.rb
+++ b/lib/origen_jtag/driver.rb
@@ -528,7 +528,7 @@ module OrigenJTAG
         else
           tdo = Reg.dummy(size)
         end
-        if !options[:read]
+        unless options[:read]
           if options[:shift_out_data]
             tdo.write(options[:shift_out_data])
             tdo.read

--- a/lib/origen_jtag_dev/top_level.rb
+++ b/lib/origen_jtag_dev/top_level.rb
@@ -40,6 +40,10 @@ module OrigenJTAGDev
         reg.bit 31..16, :bus
         reg.bit 0, :bit
       end
+
+      reg :full16, 0x0012, size: 16 do |reg|
+        reg.bit 15..0, :data
+      end
     end
 
     def instantiate_pins(options = {})

--- a/pattern/rww_test.rb
+++ b/pattern/rww_test.rb
@@ -1,0 +1,25 @@
+
+Pattern.create(options = { name: 'rww_test' }) do
+
+  jtag = $dut.jtag
+  reg = $dut.reg(:full16)
+
+  cc 'TDO should be HLHL_LHLH_HLHL_LHLH'
+  jtag.write_dr 0xFFFF, size: 16, shift_out_data: 0xA5A5
+
+  cc 'TDO should be XXXX_XXXX_HHHH_HHHH'
+  reg.write(0xFFFF)
+  reg.bits[0..7].read
+  jtag.write_dr 0xFFFF, size: 16, shift_out_data: reg
+
+
+  cc 'TDO should be HLHL_LHLH_HLHL_LHLH'
+  reg.write(0xFFFF)
+  jtag.write_dr reg, shift_out_data: 0xA5A5
+
+  cc 'TDO should be XXXX_XXXX_HHHH_HHHH'
+  reg.write(0xFFFF)
+  reg2 = reg.dup
+  reg2.bits[0..7].read
+  jtag.write_dr reg, size: 16, shift_out_data: reg2
+end


### PR DESCRIPTION
If a register is passed in options[:shift_out_data], it will be used to set the compare data on tdo.  This allows bits to be masked.