### PR TITLE
Allow 'mask' option to drop through to the bit_collection.read

### DIFF
--- a/approved/jtag_workout_RH1.atp
+++ b/approved/jtag_workout_RH1.atp
@@ -1,14 +1,14 @@
 // ***************************************************************************
 // GENERATED:
-//   Time:    28-Apr-2017 09:16AM
+//   Time:    26-Sep-2017 09:30AM
 //   By:      Lajaunie Ronald-B01784
 //   Command: origen g jtag_workout -t debug_RH1.rb -e j750.rb
 // ***************************************************************************
 // ENVIRONMENT:
 //   Application
 //     Source:    git@github.com:Origen-SDK/origen_jtag.git
-//     Version:   0.14.0
-//     Branch:    master(367fecaa95c) (+local edits)
+//     Version:   0.16.0
+//     Branch:    tdo-mask(8adedcafd3b)
 //   Origen
 //     Source:    https://github.com/Origen-SDK/origen
 //     Version:   0.7.45
@@ -611,7 +611,89 @@ repeat 15                                                        > nvmbist      
                                                                  > nvmbist                      0 0 X 1 ;
                                                                  > nvmbist                      0 0 X 0 ;
 // ######################################################################
+// ## Test - Mask option for read_dr works
+// ######################################################################
+// TDO should be H
+// Read value out of DR
+// [JTAG] Transition to Shift-DR...
+                                                                 > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+// [JTAG] Read DR: 0xFFFF
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+                                                                 > nvmbist                      0 0 X 1 ;
+// [JTAG] /Read DR: 0xFFFF
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+// ######################################################################
+// ## Test - Write value into DR, with compare on TDO
+// ######################################################################
+// Write value into DR
+// [JTAG] Transition to Shift-DR...
+                                                                 > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+// [JTAG] Write DR: 0x5555
+                                                                 > nvmbist                      0 1 L 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 1 L 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 1 L 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 1 L 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+                                                                 > nvmbist                      0 0 X 1 ;
+// [JTAG] /Write DR: 0x5555
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value out of TDO with mask
+// ######################################################################
+repeat 8                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 0 L 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 L 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 L 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value into TDI (and out of TDO)
+// ######################################################################
+                                                                 > nvmbist                      0 0 L 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 1 L 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 0 L 0 ;
+                                                                 > nvmbist                      0 1 H 0 ;
+                                                                 > nvmbist                      0 0 L 0 ;
+                                                                 > nvmbist                      0 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 1 ;
+// ######################################################################
 // ## Pattern complete
 // ######################################################################
-end_module                                                       > nvmbist                      0 0 X 0 ;
+end_module                                                       > nvmbist                      0 0 X 1 ;
 }                                                                                               

--- a/approved/jtag_workout_RH1.avc
+++ b/approved/jtag_workout_RH1.avc
@@ -1,14 +1,14 @@
 # ***************************************************************************
 # GENERATED:
-#   Time:    28-Apr-2017 09:16AM
+#   Time:    26-Sep-2017 09:30AM
 #   By:      Lajaunie Ronald-B01784
 #   Command: origen g jtag_workout -t debug_RH1.rb -e v93k.rb
 # ***************************************************************************
 # ENVIRONMENT:
 #   Application
 #     Source:    git@github.com:Origen-SDK/origen_jtag.git
-#     Version:   0.14.0
-#     Branch:    master(367fecaa95c) (+local edits)
+#     Version:   0.16.0
+#     Branch:    tdo-mask(8adedcafd3b)
 #   Origen
 #     Source:    https://github.com/Origen-SDK/origen
 #     Version:   0.7.45
@@ -919,6 +919,102 @@ R1                       nvmbist                    0 0 H 1 # ;
 # [JTAG] /Read DR: 0xFFFF
 R1                       nvmbist                    0 0 X 1 # ;
 R1                       nvmbist                    0 0 X 0 # ;
+# ######################################################################
+# ## Test - Mask option for read_dr works
+# ######################################################################
+# TDO should be H
+# Read value out of DR
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+# [JTAG] Read DR: 0xFFFF
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    0 0 X 1 # ;
+# [JTAG] /Read DR: 0xFFFF
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+# ######################################################################
+# ## Test - Write value into DR, with compare on TDO
+# ######################################################################
+# Write value into DR
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+# [JTAG] Write DR: 0x5555
+R1                       nvmbist                    0 1 L 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 1 L 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 1 L 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 1 L 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    0 0 X 1 # ;
+# [JTAG] /Write DR: 0x5555
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+# ######################################################################
+# ## Test - Shifting an explicit value out of TDO with mask
+# ######################################################################
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 L 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 0 L 0 # ;
+R1                       nvmbist                    0 0 L 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 0 L 0 # ;
+R1                       nvmbist                    0 0 L 0 # ;
+# ######################################################################
+# ## Test - Shifting an explicit value into TDI (and out of TDO)
+# ######################################################################
+R1                       nvmbist                    0 0 L 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 1 L 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 L 0 # ;
+R1                       nvmbist                    0 1 H 0 # ;
+R1                       nvmbist                    0 0 L 0 # ;
+R1                       nvmbist                    0 0 H 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 1 # ;
 # ######################################################################
 # ## Pattern complete
 # ######################################################################

--- a/approved/jtag_workout_RH2.atp
+++ b/approved/jtag_workout_RH2.atp
@@ -1,14 +1,14 @@
 // ***************************************************************************
 // GENERATED:
-//   Time:    28-Apr-2017 09:16AM
+//   Time:    26-Sep-2017 09:30AM
 //   By:      Lajaunie Ronald-B01784
 //   Command: origen g jtag_workout -t debug_RH2.rb -e j750.rb
 // ***************************************************************************
 // ENVIRONMENT:
 //   Application
 //     Source:    git@github.com:Origen-SDK/origen_jtag.git
-//     Version:   0.14.0
-//     Branch:    master(367fecaa95c) (+local edits)
+//     Version:   0.16.0
+//     Branch:    tdo-mask(8adedcafd3b)
 //   Origen
 //     Source:    https://github.com/Origen-SDK/origen
 //     Version:   0.7.45
@@ -1653,7 +1653,176 @@ stv                                                              > nvmbist      
                                                                  > nvmbist                      0 0 X 0 ;
                                                                  > nvmbist                      1 0 X 0 ;
 // ######################################################################
+// ## Test - Mask option for read_dr works
+// ######################################################################
+// TDO should be H
+// Read value out of DR
+// [JTAG] Transition to Shift-DR...
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+// [JTAG] Read DR: 0xFFFF
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+// [JTAG] /Read DR: 0xFFFF
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+// ######################################################################
+// ## Test - Write value into DR, with compare on TDO
+// ######################################################################
+// Write value into DR
+// [JTAG] Transition to Shift-DR...
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+// [JTAG] Write DR: 0x5555
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+// [JTAG] /Write DR: 0x5555
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value out of TDO with mask
+// ######################################################################
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value into TDI (and out of TDO)
+// ######################################################################
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+// ######################################################################
 // ## Pattern complete
 // ######################################################################
-end_module                                                       > nvmbist                      1 0 X 0 ;
+end_module                                                       > nvmbist                      1 0 X 1 ;
 }                                                                                               

--- a/approved/jtag_workout_RH2_1.atp
+++ b/approved/jtag_workout_RH2_1.atp
@@ -1,14 +1,14 @@
 // ***************************************************************************
 // GENERATED:
-//   Time:    28-Apr-2017 09:16AM
+//   Time:    26-Sep-2017 09:30AM
 //   By:      Lajaunie Ronald-B01784
 //   Command: origen g jtag_workout -t debug_RH2_1.rb -e j750.rb
 // ***************************************************************************
 // ENVIRONMENT:
 //   Application
 //     Source:    git@github.com:Origen-SDK/origen_jtag.git
-//     Version:   0.14.0
-//     Branch:    master(367fecaa95c) (+local edits)
+//     Version:   0.16.0
+//     Branch:    tdo-mask(8adedcafd3b)
 //   Origen
 //     Source:    https://github.com/Origen-SDK/origen
 //     Version:   0.7.45
@@ -1653,7 +1653,176 @@ stv                                                              > nvmbist      
                                                                  > nvmbist                      0 0 X 0 ;
                                                                  > nvmbist                      1 0 X 0 ;
 // ######################################################################
+// ## Test - Mask option for read_dr works
+// ######################################################################
+// TDO should be H
+// Read value out of DR
+// [JTAG] Transition to Shift-DR...
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+// [JTAG] Read DR: 0xFFFF
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+// [JTAG] /Read DR: 0xFFFF
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+// ######################################################################
+// ## Test - Write value into DR, with compare on TDO
+// ######################################################################
+// Write value into DR
+// [JTAG] Transition to Shift-DR...
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+// [JTAG] Write DR: 0x5555
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+// [JTAG] /Write DR: 0x5555
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value out of TDO with mask
+// ######################################################################
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value into TDI (and out of TDO)
+// ######################################################################
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 H 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      0 1 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+// ######################################################################
 // ## Pattern complete
 // ######################################################################
-end_module                                                       > nvmbist                      1 0 X 0 ;
+end_module                                                       > nvmbist                      1 0 X 1 ;
 }                                                                                               

--- a/approved/jtag_workout_RH4_3.atp
+++ b/approved/jtag_workout_RH4_3.atp
@@ -1,14 +1,14 @@
 // ***************************************************************************
 // GENERATED:
-//   Time:    28-Apr-2017 09:16AM
+//   Time:    26-Sep-2017 09:30AM
 //   By:      Lajaunie Ronald-B01784
 //   Command: origen g jtag_workout -t debug_RH4.rb -e j750.rb
 // ***************************************************************************
 // ENVIRONMENT:
 //   Application
 //     Source:    git@github.com:Origen-SDK/origen_jtag.git
-//     Version:   0.14.0
-//     Branch:    master(367fecaa95c) (+local edits)
+//     Version:   0.16.0
+//     Branch:    tdo-mask(8adedcafd3b)
 //   Origen
 //     Source:    https://github.com/Origen-SDK/origen
 //     Version:   0.7.45
@@ -1791,7 +1791,176 @@ repeat 2                                                         > nvmbist      
 repeat 2                                                         > nvmbist                      0 0 X 0 ;
 repeat 2                                                         > nvmbist                      1 0 X 0 ;
 // ######################################################################
+// ## Test - Mask option for read_dr works
+// ######################################################################
+// TDO should be H
+// Read value out of DR
+// [JTAG] Transition to Shift-DR...
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+// [JTAG] Read DR: 0xFFFF
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+// [JTAG] /Read DR: 0xFFFF
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+// ######################################################################
+// ## Test - Write value into DR, with compare on TDO
+// ######################################################################
+// Write value into DR
+// [JTAG] Transition to Shift-DR...
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+// [JTAG] Write DR: 0x5555
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+// [JTAG] /Write DR: 0x5555
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value out of TDO with mask
+// ######################################################################
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value into TDI (and out of TDO)
+// ######################################################################
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+// ######################################################################
 // ## Pattern complete
 // ######################################################################
-end_module                                                       > nvmbist                      1 0 X 0 ;
+end_module                                                       > nvmbist                      1 0 X 1 ;
 }                                                                                               

--- a/approved/jtag_workout_RH4_3.avc
+++ b/approved/jtag_workout_RH4_3.avc
@@ -1,14 +1,14 @@
 # ***************************************************************************
 # GENERATED:
-#   Time:    28-Apr-2017 09:16AM
+#   Time:    26-Sep-2017 09:30AM
 #   By:      Lajaunie Ronald-B01784
 #   Command: origen g jtag_workout -t debug_RH4.rb -e v93k.rb
 # ***************************************************************************
 # ENVIRONMENT:
 #   Application
 #     Source:    git@github.com:Origen-SDK/origen_jtag.git
-#     Version:   0.14.0
-#     Branch:    master(367fecaa95c) (+local edits)
+#     Version:   0.16.0
+#     Branch:    tdo-mask(8adedcafd3b)
 #   Origen
 #     Source:    https://github.com/Origen-SDK/origen
 #     Version:   0.7.45
@@ -2908,6 +2908,321 @@ R1                       nvmbist                    0 0 X 0 # ;
 R1                       nvmbist                    0 0 X 0 # ;
 R1                       nvmbist                    1 0 X 0 # ;
 R1                       nvmbist                    1 0 X 0 # ;
+# ######################################################################
+# ## Test - Mask option for read_dr works
+# ######################################################################
+# TDO should be H
+# Read value out of DR
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+# [JTAG] Read DR: 0xFFFF
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+# [JTAG] /Read DR: 0xFFFF
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+# ######################################################################
+# ## Test - Write value into DR, with compare on TDO
+# ######################################################################
+# Write value into DR
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+# [JTAG] Write DR: 0x5555
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 L 0 # ;
+R1                       nvmbist                    1 1 L 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 L 0 # ;
+R1                       nvmbist                    1 1 L 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 L 0 # ;
+R1                       nvmbist                    1 1 L 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 L 0 # ;
+R1                       nvmbist                    1 1 L 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+# [JTAG] /Write DR: 0x5555
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+# ######################################################################
+# ## Test - Shifting an explicit value out of TDO with mask
+# ######################################################################
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+# ######################################################################
+# ## Test - Shifting an explicit value into TDI (and out of TDO)
+# ######################################################################
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 L 0 # ;
+R1                       nvmbist                    1 1 L 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 H 0 # ;
+R1                       nvmbist                    1 1 H 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    1 0 L 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    1 0 H 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    0 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    1 1 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    0 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    1 0 X 0 # ;
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    0 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
+R1                       nvmbist                    1 0 X 1 # ;
 # ######################################################################
 # ## Pattern complete
 # ######################################################################

--- a/approved/jtag_workout_RL1.atp
+++ b/approved/jtag_workout_RL1.atp
@@ -1,14 +1,14 @@
 // ***************************************************************************
 // GENERATED:
-//   Time:    28-Apr-2017 09:16AM
+//   Time:    26-Sep-2017 09:30AM
 //   By:      Lajaunie Ronald-B01784
 //   Command: origen g jtag_workout -t debug_RL1.rb -e j750.rb
 // ***************************************************************************
 // ENVIRONMENT:
 //   Application
 //     Source:    git@github.com:Origen-SDK/origen_jtag.git
-//     Version:   0.14.0
-//     Branch:    master(367fecaa95c) (+local edits)
+//     Version:   0.16.0
+//     Branch:    tdo-mask(8adedcafd3b)
 //   Origen
 //     Source:    https://github.com/Origen-SDK/origen
 //     Version:   0.7.45
@@ -611,7 +611,89 @@ repeat 15                                                        > nvmbist      
                                                                  > nvmbist                      1 0 X 1 ;
                                                                  > nvmbist                      1 0 X 0 ;
 // ######################################################################
+// ## Test - Mask option for read_dr works
+// ######################################################################
+// TDO should be H
+// Read value out of DR
+// [JTAG] Transition to Shift-DR...
+                                                                 > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+// [JTAG] Read DR: 0xFFFF
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+                                                                 > nvmbist                      1 0 X 1 ;
+// [JTAG] /Read DR: 0xFFFF
+                                                                 > nvmbist                      1 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+// ######################################################################
+// ## Test - Write value into DR, with compare on TDO
+// ######################################################################
+// Write value into DR
+// [JTAG] Transition to Shift-DR...
+                                                                 > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+// [JTAG] Write DR: 0x5555
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+                                                                 > nvmbist                      1 0 X 1 ;
+// [JTAG] /Write DR: 0x5555
+                                                                 > nvmbist                      1 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value out of TDO with mask
+// ######################################################################
+repeat 8                                                         > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value into TDI (and out of TDO)
+// ######################################################################
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 1 L 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      1 1 H 0 ;
+                                                                 > nvmbist                      1 0 L 0 ;
+                                                                 > nvmbist                      1 0 H 0 ;
+                                                                 > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+// ######################################################################
 // ## Pattern complete
 // ######################################################################
-end_module                                                       > nvmbist                      1 0 X 0 ;
+end_module                                                       > nvmbist                      1 0 X 1 ;
 }                                                                                               

--- a/approved/jtag_workout_RL4_3.atp
+++ b/approved/jtag_workout_RL4_3.atp
@@ -1,14 +1,14 @@
 // ***************************************************************************
 // GENERATED:
-//   Time:    28-Apr-2017 09:16AM
+//   Time:    26-Sep-2017 09:30AM
 //   By:      Lajaunie Ronald-B01784
 //   Command: origen g jtag_workout -t debug_RL4.rb -e j750.rb
 // ***************************************************************************
 // ENVIRONMENT:
 //   Application
 //     Source:    git@github.com:Origen-SDK/origen_jtag.git
-//     Version:   0.14.0
-//     Branch:    master(367fecaa95c) (+local edits)
+//     Version:   0.16.0
+//     Branch:    tdo-mask(8adedcafd3b)
 //   Origen
 //     Source:    https://github.com/Origen-SDK/origen
 //     Version:   0.7.45
@@ -1791,7 +1791,176 @@ repeat 2                                                         > nvmbist      
 repeat 2                                                         > nvmbist                      1 0 X 0 ;
 repeat 2                                                         > nvmbist                      0 0 X 0 ;
 // ######################################################################
+// ## Test - Mask option for read_dr works
+// ######################################################################
+// TDO should be H
+// Read value out of DR
+// [JTAG] Transition to Shift-DR...
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+// [JTAG] Read DR: 0xFFFF
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+// [JTAG] /Read DR: 0xFFFF
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+// ######################################################################
+// ## Test - Write value into DR, with compare on TDO
+// ######################################################################
+// Write value into DR
+// [JTAG] Transition to Shift-DR...
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+// [JTAG] Write DR: 0x5555
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+// [JTAG] /Write DR: 0x5555
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value out of TDO with mask
+// ######################################################################
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+// ######################################################################
+// ## Test - Shifting an explicit value into TDI (and out of TDO)
+// ######################################################################
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 L 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 H 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 L 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 H 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 1 X 0 ;
+repeat 2                                                         > nvmbist                      0 1 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+// ######################################################################
 // ## Pattern complete
 // ######################################################################
-end_module                                                       > nvmbist                      0 0 X 0 ;
+end_module                                                       > nvmbist                      0 0 X 1 ;
 }                                                                                               

--- a/approved/rww_test.atp
+++ b/approved/rww_test.atp
@@ -1,14 +1,14 @@
 // ***************************************************************************
 // GENERATED:
-//   Time:    16-Jun-2017 15:28PM
-//   By:      pderouen
+//   Time:    26-Sep-2017 09:30AM
+//   By:      Lajaunie Ronald-B01784
 //   Command: origen g rww_test -t debug_RH4.rb -e j750.rb
 // ***************************************************************************
 // ENVIRONMENT:
 //   Application
 //     Source:    git@github.com:Origen-SDK/origen_jtag.git
-//     Version:   0.15.0
-//     Branch:    update_rd_while_wr(d6173ae2e97) (+local edits)
+//     Version:   0.16.0
+//     Branch:    tdo-mask(8adedcafd3b)
 //   Origen
 //     Source:    https://github.com/Origen-SDK/origen
 //     Version:   0.7.45

--- a/lib/origen_jtag/driver.rb
+++ b/lib/origen_jtag/driver.rb
@@ -525,6 +525,7 @@ module OrigenJTAG
       if reg_or_val.respond_to?(:data)
         if options[:read]
           tdo = reg_or_val.dup
+          tdo.read(options) unless options[:mask].nil?
         else
           tdo = Reg.dummy(size) unless options[:shift_out_data].is_a?(Origen::Registers::Reg)
         end
@@ -534,7 +535,7 @@ module OrigenJTAG
               tdo = options[:shift_out_data]
             else
               tdo.write(options[:shift_out_data])
-              tdo.read
+              tdo.read(options)
             end
           else
             tdo.write(0)
@@ -544,14 +545,14 @@ module OrigenJTAG
         tdo = Reg.dummy(size)
         if options[:read]
           tdo.write(reg_or_val)
-          tdo.read
+          tdo.read(options)
         else
           if options[:shift_out_data]
             if options[:shift_out_data].is_a?(Origen::Registers::Reg)
               tdo = options[:shift_out_data]
             else
               tdo.write(options[:shift_out_data])
-              tdo.read
+              tdo.read(options)
             end
           else
             tdo.write(0)

--- a/pattern/jtag_workout.rb
+++ b/pattern/jtag_workout.rb
@@ -204,4 +204,17 @@ Pattern.create(options = { name: pat_name }) do
   end
   cc 'TDO should be H'
   jtag.read_dr 0xFFFF, size: 16, msg: 'Read value out of DR'
+
+  test 'Mask option for read_dr works'
+  cc 'TDO should be H'
+  jtag.read_dr 0xFFFF, size: 16, mask: 0x5555, msg: 'Read value out of DR'
+
+  test 'Write value into DR, with compare on TDO'
+  jtag.write_dr 0x5555, size: 16, shift_out_data: 0xAAAA, mask: 0x00FF, msg: 'Write value into DR'
+
+  test 'Shifting an explicit value out of TDO with mask'
+  jtag.shift 0x1234, size: 16, read: true, mask: 0xFF00
+
+  test 'Shifting an explicit value into TDI (and out of TDO)'
+  jtag.shift 0x1234, size: 16, cycle_last: true, shift_out_data: 0xAAAA, mask: 0x0F0F
 end


### PR DESCRIPTION
Higher level register reads sometimes pass a 'mask' option to assert only specific bits, the JTAG gem used to support this but I guess it got lost somewhere along the way.  I've added it back in along with some test cases.