### PR TITLE
Dig src ovly bug

### DIFF
--- a/approved/full_reg_ovly_cap.atp
+++ b/approved/full_reg_ovly_cap.atp
@@ -1,0 +1,202 @@
+// ***************************************************************************
+// GENERATED:
+//   Time:    11-Jan-2018 14:33PM
+//   By:      nxa18793
+//   Command: origen g pattern/full_reg_ovly_cap.rb -t debug_RH4.rb -e uflex.rb
+// ***************************************************************************
+// ENVIRONMENT:
+//   Application
+//     Source:    git@github.com:Origen-SDK/origen_jtag.git
+//     Version:   0.17.1
+//     Branch:    DigSrcOvlyBug(92202937097)
+//   Origen
+//     Source:    https://github.com/Origen-SDK/origen
+//     Version:   0.26.0
+//   Plugins
+//     atp:                      0.8.0
+//     origen_doc_helpers:       0.5.0
+//     origen_testers:           0.13.2
+// ***************************************************************************
+//   DigSrc SEND count for tdi: 16                                                              
+//   DigCap Store count for tdo: 16                                                             
+import tset nvmbist;                                                                            
+opcode_mode = single;                                                                           
+digital_inst = hsdm;                                                                            
+compressed = yes;                                                                               
+instruments = {                                                                                 
+               (tdi):DigSrc 1;                                                                  
+               (tdo):DigCap 1:auto_trig_enable;                                                 
+}                                                                                               
+                                                                                                
+vm_vector                                                                                       
+full_reg_ovly_cap ($tset, tclk, tdi, tdo, tms)                                                  
+{                                                                                               
+start_label full_reg_ovly_cap_st:                                                               
+//                                                                                              t t t t
+//                                                                                              c d d m
+//                                                                                              l i o s
+//                                                                                              k      
+((tdi):DigSrc = Start)
+// [JTAG] Force transition to Run-Test/Idle...
+                                                                 > nvmbist                      0 X X 1 ; // added for digsrc start opcode
+repeat 102                                                       > nvmbist                      0 X X 1 ; // added for dssc start to send delay
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 0 ;
+repeat 2                                                         > nvmbist                      1 X X 0 ;
+repeat 2                                                         > nvmbist                      0 X X 0 ;
+repeat 2                                                         > nvmbist                      1 X X 0 ;
+// [JTAG] Transition to Shift-DR...
+repeat 2                                                         > nvmbist                      0 X X 1 ;
+repeat 2                                                         > nvmbist                      1 X X 1 ;
+repeat 2                                                         > nvmbist                      0 X X 0 ;
+repeat 2                                                         > nvmbist                      1 X X 0 ;
+repeat 2                                                         > nvmbist                      0 X X 0 ;
+repeat 2                                                         > nvmbist                      1 X X 0 ;
+// [JTAG] Write DR: 0x0
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 0 ;
+                                                                 > nvmbist                      0 D X 0 ;
+repeat 2                                                         > nvmbist                      1 D X 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+((tdi):DigSrc = SEND)                                                                           
+                                                                 > nvmbist                      0 D X 1 ;
+                                                                 > nvmbist                      0 D X 1 ;
+repeat 2                                                         > nvmbist                      1 D X 1 ;
+// [JTAG] /Write DR: 0x0
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+// [JTAG] Transition to Shift-DR...
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+// [JTAG] Read DR: 0xSSSS
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+                                                                 > nvmbist                      1 0 X 0 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 0 ;
+// [JTAG] Transition to Run-Test/Idle...
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+                                                                 > nvmbist                      1 0 X 1 ;
+((tdo):DigCap = Store),stv                                       > nvmbist                      1 0 V 1 ;
+// [JTAG] /Read DR: 0xSSSS
+repeat 2                                                         > nvmbist                      0 0 X 1 ;
+repeat 2                                                         > nvmbist                      1 0 X 1 ;
+repeat 2                                                         > nvmbist                      0 0 X 0 ;
+repeat 2                                                         > nvmbist                      1 0 X 0 ;
+// ######################################################################
+// ## Pattern complete
+// ######################################################################
+                                                                 > nvmbist                      1 0 X 0 ;
+}                                                                                               

--- a/config/commands.rb
+++ b/config/commands.rb
@@ -52,6 +52,9 @@ when "examples", "test"
   ARGV = %w(global_label_test -t debug_RH1 -e j750.rb -r approved)
   load "#{Origen.top}/lib/origen/commands/generate.rb"
 
+  ARGV = %w(full_reg_ovly_cap -t debug_RH4 -e uflex.rb -r approved)
+  load "#{Origen.top}/lib/origen/commands/generate.rb"
+
   if Origen.app.stats.changed_files == 0 &&
      Origen.app.stats.new_files == 0 &&
      Origen.app.stats.changed_patterns == 0 &&

--- a/pattern/full_reg_ovly_cap.rb
+++ b/pattern/full_reg_ovly_cap.rb
@@ -1,0 +1,12 @@
+if tester.uflex?
+  Pattern.create do
+    tester.overlay_style = :digsrc
+    dut.full16.overlay 'dummy_str'
+    dut.jtag.write_dr dut.full16
+
+    tester.capture_style = :digcap
+    dut.full16.overlay nil
+    dut.full16.store
+    dut.jtag.read_dr dut.full16
+  end
+end


### PR DESCRIPTION
Previously the MSB would never receive overlay.  This fix is to allow the overlay to take place.  The overlay settings are passed to origen_testers inside the shift function 
https://github.com/Origen-SDK/origen_jtag/blob/61860d983d41972f7f47d699e184df83dcbb0b40/lib/origen_jtag/driver.rb#L233

but that code is skipped for the last bit unless the cycle_last option is set
https://github.com/Origen-SDK/origen_jtag/blob/61860d983d41972f7f47d699e184df83dcbb0b40/lib/origen_jtag/driver.rb#L219
