### PR TITLE
Make tclk_multiple readable

### DIFF
--- a/lib/origen_jtag/driver.rb
+++ b/lib/origen_jtag/driver.rb
@@ -23,6 +23,9 @@ module OrigenJTAG
     # Returns the current value in the instruction register
     attr_reader :ir_value
 
+    # Returns the tclk multiple
+    attr_reader :tclk_multiple
+
     attr_accessor :tclk_format
     # Set true to print out debug comments about all state transitions
     attr_accessor :verbose

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -46,6 +46,11 @@ describe 'JTAG Driver Specification' do
     end
   end
 
+  it 'TCLK multiple can be queried' do
+    load_target('RL4.rb')
+    dut.jtag.tclk_multiple.should == 4
+  end
+
   it 'Raises error on instantiation with invalid pins' do
     lambda {load_target('invalid_pins')}.should raise_error
   end


### PR DESCRIPTION
Pretty straight forward.  I have a plugin that needs to be able to start and stop a free running clock on tck and need to be able to query it from the driver.