### PR TITLE
Support Custom JTAG Cycle Protocols and Clean Up

### DIFF
--- a/approved/jtag_workout_RL1_serial.avc
+++ b/approved/jtag_workout_RL1_serial.avc
@@ -1,0 +1,2283 @@
+# ***************************************************************************
+# GENERATED:
+#   Time:    18-Apr-2019 17:17PM
+#   By:      Stephen McGinty
+#   Mode:    debug
+#   Command: origen g jtag_workout -t serial_P1.rb -e v93k.rb
+# ***************************************************************************
+# ENVIRONMENT:
+#   Application
+#     Source:    git@github.com:Origen-SDK/origen_jtag.git
+#     Version:   0.20.0
+#     Branch:    serial(80bcd3e9af3) (+local edits)
+#   Origen
+#     Source:    https://github.com/Origen-SDK/origen
+#     Version:   0.42.2
+#   Plugins
+#     atp:                      0.8.0
+#     origen_doc_helpers:       0.5.0
+#     origen_testers:           0.13.2
+# ***************************************************************************
+FORMAT TCK TIO;
+#                                                   t t
+#                                                   c i
+#                                                   k o
+# ######################################################################
+# ## Test - Transition TAP controller in and out of Shift-DR
+# ######################################################################
+# [JTAG] Force transition to Run-Test/Idle...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] DR Data
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] /DR Data
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Transition TAP controller in and out of Pause-DR
+# ######################################################################
+# [JTAG] Transition to Pause-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Transition TAP controller in and out of Shift-IR
+# ######################################################################
+# [JTAG] Transition to Shift-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] IR Data
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] /IR Data
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Transition TAP controller in and out of Pause-IR
+# ######################################################################
+# [JTAG] Transition to Pause-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Transition into Shift-DR, then back and forth into Pause-DR
+# ######################################################################
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] DR Data
+# [JTAG] Transition to Pause-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Pause-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] /DR Data
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Transition into Pause-DR, then back and forth into Shift-DR
+# ######################################################################
+# [JTAG] Transition to Pause-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Pause-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Pause-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Transition into Shift-IR, then back and forth into Pause-IR
+# ######################################################################
+# [JTAG] Transition to Shift-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] IR Data
+# [JTAG] Transition to Pause-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Shift-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Pause-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Shift-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] /IR Data
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Transition into Pause-IR, then back and forth into Shift-IR
+# ######################################################################
+# [JTAG] Transition to Pause-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Shift-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Pause-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Shift-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Pause-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Shifting an explicit value into TDI
+# ######################################################################
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Shifting an explicit value out of TDO
+# ######################################################################
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 L # ;
+# ######################################################################
+# ## Test - Shift register into TDI
+# ######################################################################
+# Full register (16 bits)
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# Full register with additional size (32 bits)
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# Full register with reduced size (8 bits)
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Shift register into TDI with overlay
+# ######################################################################
+# Full register (16 bits)
+R1                       nvmbist                    1 X # ;
+SQPG JSUB write_overlay;
+# Full register with additional size (32 bits)
+R1                       nvmbist                    1 X # ;
+SQPG JSUB write_overlay;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# Full register with reduced size (8 bits)
+R1                       nvmbist                    1 X # ;
+SQPG JSUB write_overlay;
+# It should in-line overlays when running in simulation mode
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Shift register into TDI with single bit overlay
+# ######################################################################
+R1                       nvmbist                    1 X # ;
+SQPG JSUB write_overlay2;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Read register out of TDO
+# ######################################################################
+# Full register (16 bits)
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 H # ;
+# Full register with additional size (32 bits)
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# Full register with reduced size (8 bits)
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+# ######################################################################
+# ## Test - Read single bit out of TDO
+# ######################################################################
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Store register out of TDO
+# ######################################################################
+# Full register (16 bits)
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 C # ;
+# Full register with additional size (32 bits)
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# Full register with reduced size (8 bits)
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+# ######################################################################
+# ## Test - Store single bit out of TDO
+# ######################################################################
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Test flag clear, bit 0 should be read, but not stored
+# ######################################################################
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Shift register out of TDO with overlay
+# ######################################################################
+# Full register (16 bits)
+R1                       nvmbist                    1 X # ;
+SQPG JSUB read_overlay;
+# Full register with additional size (32 bits)
+R1                       nvmbist                    1 X # ;
+SQPG JSUB read_overlay;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# Full register with reduced size (8 bits)
+R1                       nvmbist                    1 X # ;
+SQPG JSUB read_overlay;
+# It should in-line overlays when running in simulation mode
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Shift register out of TDO with single bit overlay
+# ######################################################################
+R1                       nvmbist                    1 X # ;
+SQPG JSUB read_overlay2;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Write value into DR
+# ######################################################################
+# Write value into DR
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Write DR: 0xFFFF
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] /Write DR: 0xFFFF
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Write value into DR, with compare on TDO
+# ######################################################################
+# Write value into DR
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Write DR: 0xFFFF
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 H # ;
+# [JTAG] /Write DR: 0xFFFF
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Write register into DR with full-width overlay
+# ######################################################################
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Write DR: 0x0
+SQPG JSUB write_overlay;
+# [JTAG] Transition to Run-Test/Idle...
+# [JTAG] /Write DR: 0x0
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Read value out of DR
+# ######################################################################
+# Read value out of DR
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Read DR: 0xFFFF
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 H # ;
+# [JTAG] /Read DR: 0xFFFF
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Store value out of DR
+# ######################################################################
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Read DR: 0xSSSSSSSS
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 C # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 C # ;
+# [JTAG] /Read DR: 0xSSSSSSSS
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Read value out of DR, with specified shift in data into TDI
+# ######################################################################
+# Read value out of DR
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Read DR: 0xFFFF
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 H # ;
+# [JTAG] /Read DR: 0xFFFF
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Write value into IR
+# ######################################################################
+# Write value into IR
+# [JTAG] Transition to Shift-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Write IR: 0xF
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] /Write IR: 0xF
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Read value out of IR
+# ######################################################################
+# Read value out of IR
+# [JTAG] Transition to Shift-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Read IR: 0xF
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 H # ;
+# [JTAG] /Read IR: 0xF
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - The IR value is tracked and duplicate writes are inhibited
+# ######################################################################
+# ######################################################################
+# ## Test - Unless forced
+# ######################################################################
+# [JTAG] Transition to Shift-IR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Write IR: 0xF
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] /Write IR: 0xF
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Reset
+# ######################################################################
+# [JTAG] Force transition to Test-Logic-Reset...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Mask option for read_dr works
+# ######################################################################
+# TDO should be H
+# Read value out of DR
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Read DR: 0xFFFF
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] /Read DR: 0xFFFF
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Write value into DR, with compare on TDO
+# ######################################################################
+# Write value into DR
+# [JTAG] Transition to Shift-DR...
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Write DR: 0x5555
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] Transition to Run-Test/Idle...
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# [JTAG] /Write DR: 0x5555
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Test - Shifting an explicit value out of TDO with mask
+# ######################################################################
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+# ######################################################################
+# ## Test - Shifting an explicit value into TDI (and out of TDO)
+# ######################################################################
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 L # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 H # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 X # ;
+R1                       nvmbist                    1 0 # ;
+R1                       nvmbist                    1 1 # ;
+R1                       nvmbist                    1 X # ;
+# ######################################################################
+# ## Pattern complete
+# ######################################################################
+SQPG STOP;

--- a/config/commands.rb
+++ b/config/commands.rb
@@ -93,6 +93,9 @@ when "examples", "test"
   ARGV = %w(jtag_workout -t new_P4 -e v93k -r approved)
   load "#{Origen.top}/lib/origen/commands/generate.rb"
 
+  ARGV = %w(jtag_workout -t serial_P1 -e v93k -r approved)
+  load "#{Origen.top}/lib/origen/commands/generate.rb"
+
   if Origen.app.stats.changed_files == 0 &&
      Origen.app.stats.new_files == 0 &&
      Origen.app.stats.changed_patterns == 0 &&

--- a/lib/origen_jtag/driver.rb
+++ b/lib/origen_jtag/driver.rb
@@ -321,10 +321,6 @@ module OrigenJTAG
         mask_tdo_half1 =  ((@tck_format == :rl) && (@tdo_strobe == :tck_high) && (@tck_multiple > 1)) ||
                           ((@tck_format == :rh) && (@tdo_strobe == :tck_low) && (@tck_multiple > 1))
 
-        # determine whether TDO is set to capture for this TCK cycle
-        # Is this ever the case Paul Derouen? This line can be commented out without any effect on the test cases
-        # tdo_to_be_captured = @pins[:tdo].to_be_captured?
-
         # If TDO is already suspended (by an application) then don't do the
         # suspends below since the resume will clear the application's suspend
         tdo_already_suspended = !cycle_callback? && @pins[:tdo].suspended? && !@tdo_suspended_by_driver
@@ -338,7 +334,6 @@ module OrigenJTAG
             # first half of cycle
             @pins[:tck].drive(@tck_vals ? @tck_vals[:on] : tck_val)
             unless tdo_already_suspended
-              # unless tdo_to_be_captured
               if mask_tdo_half0
                 @tdo_suspended_by_driver = true
                 @pins[:tdo].suspend
@@ -346,13 +341,11 @@ module OrigenJTAG
                 @tdo_suspended_by_driver = false
                 @pins[:tdo].resume
               end
-              # end
             end
           else
             # second half of cycle
             @pins[:tck].drive(@tck_vals ? @tck_vals[:off] : (1 - tck_val))
             unless tdo_already_suspended
-              # unless tdo_to_be_captured
               if mask_tdo_half1
                 @tdo_suspended_by_driver = true
                 @pins[:tdo].suspend
@@ -360,7 +353,6 @@ module OrigenJTAG
                 @tdo_suspended_by_driver = false
                 @pins[:tdo].resume
               end
-              # end
             end
           end
           yield
@@ -541,14 +533,9 @@ module OrigenJTAG
     private
 
     def action(pin_id, *operations)
-      options = operations.pop if operations.last.is_a?(Hash)
       @actions ||= clear_actions
       if pin_id == :store
         @actions[:store] = true
-      elsif pin_id == :suspend
-        @actions[:suspend] = true
-      elsif pin_id == :resume
-        @actions[:resume] = true
       else
         fail "Unkown JTAG pin ID: #{pin_id}" unless @actions[pin_id]
         @actions[pin_id] << operations

--- a/lib/origen_jtag_dev/new_style.rb
+++ b/lib/origen_jtag_dev/new_style.rb
@@ -50,12 +50,10 @@ module OrigenJTAGDev
     end
 
     def instantiate_pins(options = {})
-      if options[:invalid_pins]
-        add_pin :tck
-      else
-        add_pin :tclk
+      add_pin :tclk
+      unless options[:invalid_pins]
+        add_pin :tdi
       end
-      add_pin :tdi
       add_pin :tdo
       add_pin :tms
 
@@ -101,7 +99,7 @@ module OrigenJTAGDev
       @jtag_config[:init_state]
     end
 
-    # Wouldn't want to do this in reality, but allows some flexibility duing gem testing
+    # Wouldn't want to do this in reality, but allows some flexibility during gem testing
     def update_jtag_config(cfg, val)
       if @jtag_config.key?(cfg)
         @jtag_config[cfg] = val

--- a/lib/origen_jtag_dev/new_style.rb
+++ b/lib/origen_jtag_dev/new_style.rb
@@ -24,6 +24,7 @@ module OrigenJTAGDev
       @jtag_config[:tdo_store_cycle] = options[:tdo_store_cycle] if options[:tdo_store_cycle]
       @jtag_config[:init_state] = options[:init_state] if options[:init_state]
       @jtag_config[:tclk_vals] = options[:tclk_vals] if options[:tclk_vals]
+      @jtag_config[:cycle_callback] = options[:cycle_callback] if options[:cycle_callback]
 
       instantiate_registers(options)
       instantiate_pins(options)

--- a/lib/origen_jtag_dev/serial.rb
+++ b/lib/origen_jtag_dev/serial.rb
@@ -4,78 +4,21 @@ module OrigenJTAGDev
   # during development.
   #
   # It is not included when this library is imported.
-  class Serial
-    include Origen::TopLevel
-
-    def initialize(options = {})
-      @jtag_config = {
-        verbose:         true,
-        tclk_format:     options[:tclk_format] || :rh,
-        tclk_multiple:   options[:tclk_multiple] || 1,
-        tdo_strobe:      options[:tdo_strobe] || :tclk_high,
-        tdo_store_cycle: options[:tdo_store_cycle] || 0,
-        init_state:      options[:init_state] || :unknown,
-        cycle_callback:  :jtag_cycle
-      }
-
+  class Serial < NewStyle
+    def instantiate_pins(options = {})
       add_pin :tck
       add_pin :tio
-
-      instantiate_registers(options)
-      sub_block :jtag, { class_name: 'OrigenJTAG::Driver' }.merge(@jtag_config)
     end
 
     def jtag_cycle(actions, options = {})
-      apply_action(pin(:tio), actions[:tdi])
+      pin(:tck).drive(1)
+      jtag.apply_action(pin(:tio), actions[:tdi])
       tester.cycle(options)
-      apply_action(pin(:tio), actions[:tms])
+      jtag.apply_action(pin(:tio), actions[:tms])
       tester.cycle(options)
-      apply_action(pin(:tio), actions[:tdo])
+      jtag.apply_action(pin(:tio), actions[:tdo])
       tester.store_next_cycle(pin(:tio)) if actions[:store]
       tester.cycle(options)
-    end
-
-    def apply_action(pin, actions)
-      actions.each do |operation|
-        method = operation.shift
-        pin.send(method, *operation) if method
-      end
-    end
-
-    def startup(options = {})
-      tester.set_timeset('nvmbist', 40)
-      pin(:tck).drive(1)
-    end
-
-    # Getter for top-level tclk_format setting
-    def tclk_format
-      @jtag_config[:tclk_format]
-    end
-
-    # Getter for top-level tclk_multiple setting
-    def tclk_multiple
-      @jtag_config[:tclk_multiple]
-    end
-
-    # Getter for top-level tdo_store_cycle setting
-    def tdo_store_cycle
-      @jtag_config[:tdo_store_cycle]
-    end
-
-    def instantiate_registers(options = {})
-      reg :test16, 0x0012, size: 16 do |reg|
-        reg.bit 15..8, :bus
-        reg.bit 0, :bit
-      end
-
-      reg :test32, 0x0014, size: 32 do |reg|
-        reg.bit 31..16, :bus
-        reg.bit 0, :bit
-      end
-
-      reg :full16, 0x0012, size: 16 do |reg|
-        reg.bit 15..0, :data
-      end
     end
   end
 end

--- a/lib/origen_jtag_dev/serial.rb
+++ b/lib/origen_jtag_dev/serial.rb
@@ -1,0 +1,47 @@
+module OrigenJTAGDev
+  # This is a dummy DUT model which is used
+  # to instantiate and test the JTAG locally
+  # during development.
+  #
+  # It is not included when this library is imported.
+  class Serial
+    include Origen::TopLevel
+
+    def initialize(options = {})
+      @jtag_config = {
+        verbose:         true,
+        tclk_format:     options[:tclk_format] || :rh,
+        tclk_multiple:   options[:tclk_multiple] || 1,
+        tdo_strobe:      options[:tdo_strobe] || :tclk_high,
+        tdo_store_cycle: options[:tdo_store_cycle] || 0,
+        init_state:      options[:init_state] || :unknown,
+        cycle_callback:  :jtag_cycle
+      }
+
+      add_pin :tck
+      add_pin :tio
+
+      instantiate_registers(options)
+      sub_block :jtag, { class_name: 'OrigenJTAG::Driver' }.merge(@jtag_config)
+    end
+
+    def jtag_cycle(actions)
+    end
+
+    def instantiate_registers(options = {})
+      reg :test16, 0x0012, size: 16 do |reg|
+        reg.bit 15..8, :bus
+        reg.bit 0, :bit
+      end
+
+      reg :test32, 0x0014, size: 32 do |reg|
+        reg.bit 31..16, :bus
+        reg.bit 0, :bit
+      end
+
+      reg :full16, 0x0012, size: 16 do |reg|
+        reg.bit 15..0, :data
+      end
+    end
+  end
+end

--- a/lib/origen_jtag_dev/serial.rb
+++ b/lib/origen_jtag_dev/serial.rb
@@ -25,7 +25,41 @@ module OrigenJTAGDev
       sub_block :jtag, { class_name: 'OrigenJTAG::Driver' }.merge(@jtag_config)
     end
 
-    def jtag_cycle(actions)
+    def jtag_cycle(actions, options = {})
+      apply_action(pin(:tio), actions[:tdi])
+      tester.cycle(options)
+      apply_action(pin(:tio), actions[:tms])
+      tester.cycle(options)
+      apply_action(pin(:tio), actions[:tdo])
+      tester.store_next_cycle(pin(:tio)) if actions[:store]
+      tester.cycle(options)
+    end
+
+    def apply_action(pin, actions)
+      actions.each do |operation|
+        method = operation.shift
+        pin.send(method, *operation) if method
+      end
+    end
+
+    def startup(options = {})
+      tester.set_timeset('nvmbist', 40)
+      pin(:tck).drive(1)
+    end
+
+    # Getter for top-level tclk_format setting
+    def tclk_format
+      @jtag_config[:tclk_format]
+    end
+
+    # Getter for top-level tclk_multiple setting
+    def tclk_multiple
+      @jtag_config[:tclk_multiple]
+    end
+
+    # Getter for top-level tdo_store_cycle setting
+    def tdo_store_cycle
+      @jtag_config[:tdo_store_cycle]
     end
 
     def instantiate_registers(options = {})

--- a/pattern/jtag_workout.rb
+++ b/pattern/jtag_workout.rb
@@ -1,5 +1,6 @@
 pat_name = "jtag_workout_#{$dut.tclk_format.upcase}#{$dut.tclk_multiple}"
 pat_name = pat_name + "_#{dut.tdo_store_cycle}" if dut.tdo_store_cycle != 0
+pat_name += "_serial" if dut.is_a?(OrigenJTAGDev::Serial)
 pat_name += "_tclk_vals" if dut.try(:tclk_vals)
 
 Pattern.create(options = { name: pat_name }) do
@@ -196,15 +197,17 @@ Pattern.create(options = { name: pat_name }) do
   test 'Reset'
   jtag.reset
 
-  test 'Suspend of compare on TDO works'
-  cc 'TDO should be H'
-  jtag.read_dr 0xFFFF, size: 16, msg: 'Read value out of DR'
-  tester.ignore_fails($dut.pin(:tdo)) do
-    cc 'TDO should be X'
+  if dut.has_pin?(:tdo)
+    test 'Suspend of compare on TDO works'
+    cc 'TDO should be H'
+    jtag.read_dr 0xFFFF, size: 16, msg: 'Read value out of DR'
+    tester.ignore_fails($dut.pin(:tdo)) do
+      cc 'TDO should be X'
+      jtag.read_dr 0xFFFF, size: 16, msg: 'Read value out of DR'
+    end
+    cc 'TDO should be H'
     jtag.read_dr 0xFFFF, size: 16, msg: 'Read value out of DR'
   end
-  cc 'TDO should be H'
-  jtag.read_dr 0xFFFF, size: 16, msg: 'Read value out of DR'
 
   test 'Mask option for read_dr works'
   cc 'TDO should be H'

--- a/target/serial_P1.rb
+++ b/target/serial_P1.rb
@@ -1,0 +1,1 @@
+OrigenJTAGDev::Serial.new(tclk_format: :rl, tclk_multiple: 1)

--- a/target/serial_P1.rb
+++ b/target/serial_P1.rb
@@ -1,1 +1,3 @@
-OrigenJTAGDev::Serial.new(tclk_format: :rl, tclk_multiple: 1)
+OrigenJTAGDev::Serial.new(tclk_format: :rl, tclk_multiple: 1,
+                          cycle_callback: :jtag_cycle
+                         )

--- a/templates/web/index.md.erb
+++ b/templates/web/index.md.erb
@@ -26,24 +26,42 @@ or if your application is a plugin add this to your <code>.gemspec</code>
 spec.add_development_dependency "origen_jtag", ">= <%= Origen.app.version %>"
 ~~~
 
-__NOTE:__ You will also need to include <code>require 'origen_jtag'</code> somewhere in your environment.  This can be done in <code>config/environment.rb</code> for example.
+__NOTE:__ You will also need to include <code>require 'origen_jtag'</code> somewhere in your environment.
+This can be done in <code>config/environment.rb</code> for example.
 
 ### How To Use
 
-#### New Style Example
+#### Integration
 
-The driver no longer requires specific pin names (or aliases), supports sub_block instantiation and DUTs with multiple JTAG ports.
- You are no longer required to include "OrigenJTAG" in your DUT class.
-
-Here is an example integration:
+This plugin provides a JTAG driver that should be instantiated by the top-level DUT model as shown in this
+basic integration example:
 
 ~~~ruby
-class Pioneer
+class MyApp::MyDUT
+  include Origen::TopLevel
 
+  def initialize(options = {})
+    # The JTAG driver will use these pins by default if they are defined (or aliases)
+    add_pin :tck
+    add_pin :tdi
+    add_pin :tdo
+    add_pin :tms
+
+    sub_block :jtag, class_name: 'OrigenJTAG::Driver'
+  end
+end
+~~~
+
+Multiple JTAG blocks can be instantiated if the DUT has multiple JTAG ports, and each one can be individually
+customized as shown in this more complex example:
+
+~~~ruby
+class MyApp::MyDUT
   include Origen::TopLevel
 
   def initialize
-    add_pin :tclk
+    # The JTAG driver will use these pins by default if they are defined (or aliases)
+    add_pin :tck
     add_pin :tdi
     add_pin :tdo
     add_pin :tms
@@ -58,92 +76,48 @@ class Pioneer
     # 2 high then 2 low for each effective TCK pulse.
     # Strobe TDO only when TCK high.  Only store TDO on last cycle (3)
 
-    # several pluggins use dut.jtag, your default port driver should be named jtag for compatibility
+    # Several plugins use dut.jtag, your default port driver should be named jtag for compatibility
     sub_block :jtag, class_name: 'OrigenJTAG::Driver',
-                     tclk_format:       :rl,
-                     tclk_multiple:     4,
-                     tdo_strobe:        :tclk_high,
-                     tdo_store_cycle:   3,
-                     tck_pin:           pin(:tclk),
-                     tdi_pin:           pin(:tdi),
-                     tdo_pin:           pin(:tdo),
-                     tms_pin:           pin(:tms)
+                     tck_format:        :rl,
+                     tck_multiple:      4,
+                     tdo_strobe:        :tck_high,
+                     tdo_store_cycle:   3
 
-    # create a driver for a 2nd port like this
-    # note different configuration settings can be used
+    # Create a driver for a 2nd port like this, note different configuration settings can be used
     sub_block :jtag_port2, class_name: 'OrigenJTAG::Driver',
-                     tclk_format:       :rh,
-                     tclk_multiple:     2,
-                     tdo_strobe:        :tclk_high,
+                     tck_format:        :rh,
+                     tck_multiple:      2,
+                     tdo_strobe:        :tck_high,
                      tdo_store_cycle:   1,
                      tck_pin:           pin(:tck2),
                      tdi_pin:           pin(:tdi2),
                      tdo_pin:           pin(:tdo2),
                      tms_pin:           pin(:tms2)
   end
-
 end
 
-dut.jtag                # => jtag driver for the first port (tclk, tdi, tdo, tms)
+dut.jtag                # => jtag driver for the first port (tck, tdi, tdo, tms)
 dut.jtag_port2          # => jtag driver for the second port (tck2, tdi2, tdo2, tms2)
 ~~~
 
+Here are some of the most common configuration options:
+
+* **tck_format** - TCK timing format,  Return High (:rh) or Return Low (:rl). Default is :rh.
+* **tck_multiple** - Number of cycles for a single TCK pulse to cover, to support cases where TCK needs to be a fraction of another clock period. Assumes 50% duty cycle, specify only even numbers if > 1. Default is :r1.
+* **tdo_strobe** - When using multiple cycles for TCK, which state of TCK to strobe for TDO, :tck_high or :tck_low or :tck_all. Default :tck_high.
+* **tdo_store_cycle** - When using multiple cycles for TCK, which cycle of TCK to store for TDO if store requested (0 to number of tck_multiple-1). Default 0
+
 By default, the driver will apply the conventional '1' and '0' drive values on the TCK pin to turn
 the clock on and off, however
-this can be overridden by supplying the `:tclk_vals` option as shown in the example below:
+this can be overridden by supplying the `:tck_vals` option as shown in the example below:
 
 ~~~ruby
 # My V93K timing setup uses 'P' to enable a clock pulse instead of '1'
-tclk_vals: { on: 'P', off: 0 }
+tck_vals: { on: 'P', off: 0 }
 ~~~
 
-
-#### Legacy Example
-
-Include the <code>OrigenJTAG</code> module to add a JTAG driver to your class and
-define the required pins.
-Normally the pins would be an alias to existing DUT pins and therefore the
-JTAG driver module cannot assume them.
-
-Including the module adds a <code>jtag</code> method which will return an instance of
-[<code>OrigenJTAG::Driver</code>](<%= path "api/OrigenJTAG/Driver.html" %>).
-
-The following attributes can be customized by defining a <code>JTAG_CONFIG</code>
-hash:
-
-* **tclk_format** - TCLK timing format,  Return High (:rh) or Return Low (:rl). Default is :rh.
-* **tclk_multiple** - Number of cycles for a single TCLK pulse to cover, to support cases where TCLK needs to be a fraction of another clock period. Assumes 50% duty cycle, specify only even numbers if > 1. Default is :r1.
-* **tdo_strobe** - When using multiple cycles for TCK, which state of TCK to strobe for TDO, :tclk_high or :tclk_low or :tclk_all. Default :tclk_high.
-* **tdo_store_cycle** - When using multiple cycles for TCK, which cycle of TCK to store for TDO if store requested (0 to number of tclk_multiple-1). Default 0
-
-Here is an example integration:
-
-~~~ruby
-class Pioneer
-
-  include OrigenJTAG
-  include Origen::Pins
-
-  # TCK covers 4 tester cycles, 2 high then 2 low for each effective TCK pulse
-  # Strobe TDO only when TCK high.  Only store TDO on last cycle (3)
-  JTAG_CONFIG = {
-    :tclk_format => :rl,
-    :tclk_multiple => 4,
-    :tdo_strobe => :tclk_high,
-    :tdo_store_cycle => 3,
-  }
-
-  def initialize
-    add_pin :tclk
-    add_pin :tdi
-    add_pin :tdo
-    add_pin :tms
-  end
-
-end
-
-Pioneer.new.jtag  # => An instance of OrigenJTAG::Driver
-~~~
+A [legacy integration is also supported](<%= path "legacy" %>), but not recommended for new projects
+as it may be deprecated in future.
 
 #### APIs
 
@@ -203,6 +177,57 @@ def on_jtag_state_change(new_state)
 end
 ~~~
 
+#### Custom JTAG Cycle Protocols
+
+This plugin also allows applications to define how a JTAG cycle should be implemented at the
+pin-level, providing the flexibility to handle hybrid JTAG protocols.
+An example would be an ultra-low pincount device where the JTAG signals are multiplexed down a
+single wire.
+
+To implement a custom protocol, a `:cycle_callback` option should be supplied when instantiating the
+driver to specify the name of the DUT method that will implement the cycle.
+**Note that most other configuration options are meaningless in this context (and some non-default
+values will raise an error) because the application
+is now taking full responsibility for how a JTAG cycle is implemented.**
+Similarly, there is no requirement for the conventional JTAG pins to be present or specified when this
+option is given since the driver is no longer responsible for the vector generation.
+
+The given method should accept two arguments:
+
+* **actions** - A hash containing the actions that should be applied to the `:tdi`, `:tms` and `:tdo`,
+  pins and a boolean flag called `:store` which indicates if TDO should be stored/captured on this cycle
+* **options** - Any options that should be passed to the tester when calling `tester.cycle`
+
+The JTAG driver provides a method called `apply_action` which accepts a pin object and the pin-specific
+actions from the actions hash, e.g.
+
+~~~ruby
+jtag.apply_action(pin(:my_pin), actions[:tms])
+~~~
+
+Here is a complete example which would serialize TDI, TMS and TDO on a single pin:
+
+~~~ruby
+class MyApp::MyDUT
+  def initialize(options = {})
+    add_pin :tck
+    add_pin :tio
+
+    sub_block :jtag, class_name: 'OrigenJTAG::Driver', cycle_callback: :jtag_cycle
+  end
+
+  def jtag_cycle(actions, options = {})
+    pin(:tck).drive(1)
+    jtag.apply_action(pin(:tio), actions[:tdi])
+    tester.cycle(options)
+    jtag.apply_action(pin(:tio), actions[:tms])
+    tester.cycle(options)
+    jtag.apply_action(pin(:tio), actions[:tdo])
+    tester.store_next_cycle(pin(:tio)) if actions[:store]
+    tester.cycle(options)
+  end
+end
+~~~
 
 ### How To Setup a Development Environment
 

--- a/templates/web/legacy.md.erb
+++ b/templates/web/legacy.md.erb
@@ -1,0 +1,43 @@
+% render "layouts/basic.html" do
+
+### Legacy Integration
+
+The following approach to adding an JTAG driver is still supported, however new projects
+should use the new style integration as described [on the home page](<%= path "/" %>).
+
+Include the <code>OrigenJTAG</code> module to add a JTAG driver to your class and
+define the required pins.
+Normally the pins would be an alias to existing DUT pins and therefore the
+JTAG driver module cannot assume them.
+
+Including the module adds a <code>jtag</code> method which will return an instance of
+[<code>OrigenJTAG::Driver</code>](<%= path "api/OrigenJTAG/Driver.html" %>).
+
+Here is an example integration:
+
+~~~ruby
+class MyApp::MyDUT
+  include Origen::TopLevel
+  include OrigenJTAG
+
+  # TCK covers 4 tester cycles, 2 high then 2 low for each effective TCK pulse
+  # Strobe TDO only when TCK high.  Only store TDO on last cycle (3)
+  JTAG_CONFIG = {
+    :tck_format => :rl,
+    :tck_multiple => 4,
+    :tdo_strobe => :tck_high,
+    :tdo_store_cycle => 3,
+  }
+
+  def initialize
+    add_pin :tck
+    add_pin :tdi
+    add_pin :tdo
+    add_pin :tms
+  end
+end
+
+MyApp::MyDUT.new.jtag  # => An instance of OrigenJTAG::Driver
+~~~
+
+% end


### PR DESCRIPTION
This PR includes the following:

* Adds a new feature to allow applications to define how JTAG cycles are implemented at the pin-level.
* Updated all documentation and internal code to reference TCK instead of TCLK, though in all cases the TCLK versions of pin names and options are still supported.
* Adds documentation for the new feature (below) and some general clean up of the existing docs - moves the legacy integration description to another page to give it less prominence going forward.

#### Custom JTAG Cycle Protocols

This plugin also allows applications to define how a JTAG cycle should be implemented at the
pin-level, providing the flexibility to handle hybrid JTAG protocols.
An example would be an ultra-low pincount device where the JTAG signals are multiplexed down a
single wire.

To implement a custom protocol, a `:cycle_callback` option should be supplied when instantiating the
driver to specify the name of the DUT method that will implement the cycle.
**Note that most other configuration options are meaningless in this context (and some non-default
values will raise an error) because the application
is now taking full responsibility for how a JTAG cycle is implemented.**
Similarly, there is no requirement for the conventional JTAG pins to be present or specified when this
option is given since the driver is no longer responsible for the vector generation.

The given method should accept two arguments:

* **actions** - A hash containing the actions that should be applied to the `:tdi`, `:tms` and `:tdo`,
  pins and a boolean flag called `:store` which indicates if TDO should be stored/captured on this cycle
* **options** - Any options that should be passed to the tester when calling `tester.cycle`

The JTAG driver provides a method called `apply_action` which accepts a pin object and the pin-specific
actions from the actions hash, e.g.

~~~ruby
jtag.apply_action(pin(:my_pin), actions[:tms])
~~~

Here is a complete example which would serialize TDI, TMS and TDO on a single pin:

~~~ruby
class MyApp::MyDUT
  def initialize(options = {})
    add_pin :tck
    add_pin :tio

    sub_block :jtag, class_name: 'OrigenJTAG::Driver', cycle_callback: :jtag_cycle
  end

  def jtag_cycle(actions, options = {})
    pin(:tck).drive(1)
    jtag.apply_action(pin(:tio), actions[:tdi])
    tester.cycle(options)
    jtag.apply_action(pin(:tio), actions[:tms])
    tester.cycle(options)
    jtag.apply_action(pin(:tio), actions[:tdo])
    tester.store_next_cycle(pin(:tio)) if actions[:store]
    tester.cycle(options)
  end
end
~~~
