### PR TITLE
Changed tdo_store_cycle and tdo_strobe to accessors

### DIFF
--- a/lib/origen_jtag/driver.rb
+++ b/lib/origen_jtag/driver.rb
@@ -35,7 +35,8 @@ module OrigenJTAG
     alias_method :tclk_format, :tck_format
     alias_method :tclk_format=, :tck_format=
 
-    attr_reader :tdo_strobe
+    attr_accessor :tdo_strobe
+    attr_accessor :tdo_store_cycle
 
     # Set true to print out debug comments about all state transitions
     attr_accessor :verbose

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -60,4 +60,15 @@ describe 'JTAG Driver Specification' do
     dut.jtag.respond_to?(:tclk_cycle).should == true
   end
 
+  it 'tdo_store_cycle and tdo_strobe can be accessed' do
+    load_target('RL4.rb')
+    dut.jtag.tdo_store_cycle.should == 3
+    dut.jtag.tdo_store_cycle = 2
+    dut.jtag.tdo_store_cycle.should == 2
+
+    dut.jtag.tdo_strobe.should == :tck_high
+    dut.jtag.tdo_strobe = :tck_low
+    dut.jtag.tdo_strobe.should == :tck_low
+  end
+
 end


### PR DESCRIPTION
When changing tclk_multiple, these usually need to change as well.  Updated driver.rb to define tdo_store_cycle and tdo_strobe as accessors.