### PR TITLE
ruby 3.x compatibility

### DIFF
--- a/lib/origen_jtag/driver.rb
+++ b/lib/origen_jtag/driver.rb
@@ -568,7 +568,7 @@ module OrigenJTAG
     def extract_size(reg_or_val, options = {})
       size = options[:size]
       unless size
-        if reg_or_val.is_a?(Fixnum) || !reg_or_val.respond_to?(:size)
+        if reg_or_val.is_a?(Integer) || !reg_or_val.respond_to?(:size)
           fail 'When suppling a value to JTAG::Driver#shift you must supply a :size in the options!'
         else
           size = reg_or_val.size


### PR DESCRIPTION
I have no idea why, but when running on Ruby 3.2, Ruby is expecting Fixnum to be a class defined by OrigenJTAG:

COMPLETE CALL STACK
-------------------
uninitialized constant OrigenJTAG::Driver::Fixnum

is_a?(Integer) works in the Ruby versions I checked (2.6, 2.7, 3.2)